### PR TITLE
Checks for max stack or sets to 64, no more infinity

### DIFF
--- a/inventory-creative.coffee
+++ b/inventory-creative.coffee
@@ -107,4 +107,5 @@ class CreativeInventoryPlugin extends InventoryDialog
     items = categories[category] ? []
 
     for name, i in items
-      @thisInventory.set i, new ItemPile(name, Infinity)
+      number = @registry.getProp('maxStack') or 64
+      @thisInventory.set i, new ItemPile(name, number)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-inventory-creative",
   "description": "inventory dialog with an infinite supply of all items (voxel.js plugin)",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "inventory-creative.coffee",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The items/blocks are no longer set to infinity which solves the problem of changing back to survival and still having a block called infinity. The problem now is that in creative mode the block still goes down from 64 when used, this is better solved in the actual plugin that does the:

64 - 1 = 63

to get the next number and set it to not change in creative mode.